### PR TITLE
using importlib.metadata instead of pkg_resources in init for version

### DIFF
--- a/fvpy/__init__.py
+++ b/fvpy/__init__.py
@@ -2,9 +2,9 @@
 
 __all__ = ["__version__"]
 
-import pkg_resources
+import importlib.metadata
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.DistributionNotFound:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
     pass


### PR DESCRIPTION
Using `importlib.metadata` instead of `pkg_resources` in `__init__.py` because of deprecation message of `pkg_resources`.