### PR TITLE
first fvpy menu

### DIFF
--- a/fvpy/menu/__init__.py
+++ b/fvpy/menu/__init__.py
@@ -1,3 +1,3 @@
-from .menu_bar import FileMenu, MenuBar, ViewMenu
+from .menu_bar import FileMenu, FvPyMenu, MenuBar, ViewMenu
 
-__all__ = ["MenuBar", "FileMenu", ViewMenu]
+__all__ = ["MenuBar", "FileMenu", "ViewMenu", "FvPyMenu"]

--- a/fvpy/menu/menu_bar.py
+++ b/fvpy/menu/menu_bar.py
@@ -1,7 +1,7 @@
 from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import QAction, QMenu, QMenuBar
 
-__all__ = ["MenuBar", "FileMenu"]
+__all__ = ["MenuBar", "FileMenu", "ViewMenu", "FvPyMenu"]
 
 
 class MenuBar(QMenuBar):
@@ -12,12 +12,35 @@ class MenuBar(QMenuBar):
 
         self.main_window = main_window
 
+        self.fvpy_menu = FvPyMenu(main_window=self.main_window)
+        self.addMenu(self.fvpy_menu)
+
         self.file_menu = FileMenu(main_window=self.main_window)
         self.addMenu(self.file_menu)
+
         self.edit_menu = self.addMenu("Edit")
+
         self.view_menu = ViewMenu(main_window=self.main_window)
         self.addMenu(self.view_menu)
+
         self.help_menu = self.addMenu("Help")
+
+
+class FvPyMenu(QMenu):
+    """FvPy menu for the main window."""
+
+    def __init__(self, parent=None, main_window=None):
+        super().__init__("FvPy", parent)
+
+        self.main_window = main_window
+
+        self.about_action = QAction("About FvPy", self)
+        self.addAction(self.about_action)
+
+        self.addSeparator()
+
+        self.setting_action = QAction("Settings", self)
+        self.addAction(self.setting_action)
 
 
 class FileMenu(QMenu):

--- a/fvpy/window/mainwindow.py
+++ b/fvpy/window/mainwindow.py
@@ -15,3 +15,6 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.centralWidget)
         self.menu_bar = MenuBar(main_window=self)
         self.setMenuBar(self.menu_bar)
+        # If on macOS, the following line is needed to show the fvpy menu of the menu bar.
+        # Otherwise, the fvpy menu is hidden under the macOS application menu named python.
+        # self.menu_bar.setNativeMenuBar(False)


### PR DESCRIPTION
First fvpy menu 
It is override by the the python menu in mac if `MenuBarsetNativeMenuBar(True)`. 
Turn it to `False` to see the fvpy menu. However, the menu then does inside the main window. This is not wanted. But this issue will be fixed when creating a proper app.